### PR TITLE
Fix CI dependency conflicts: upgrade to Python 3.11+, sync transforme…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'pip'
       - name: Install pre-commit
         run: |
@@ -32,7 +32,7 @@ jobs:
     needs: precommit
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.11', '3.12' ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -60,7 +60,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.11', '3.12' ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -110,18 +110,18 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'pip'
       - name: Restore venv cache
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-3.10-${{ hashFiles('requirements.lock.txt', 'requirements.txt') }}
+          key: venv-${{ runner.os }}-3.11-${{ hashFiles('requirements.lock.txt', 'requirements.txt') }}
           restore-keys: |
-            venv-${{ runner.os }}-3.10-
+            venv-${{ runner.os }}-3.11-
       - name: Install dependencies
         run: |
           python -m venv .venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ spacy==3.7.4
 imbalanced-learn==0.12.2
 # Heavy packages pinned to ensure Linux wheels
 torch==2.2.2
-transformers==4.41.2
-tokenizers==0.15.2
+transformers==4.55.2
+tokenizers==0.21.4
 accelerate==0.30.1
 datasets==2.19.0
 mlflow==2.12.1


### PR DESCRIPTION
…rs/tokenizers versions, regenerate requirements.lock.txt

- CI now uses Python 3.11/3.12 (supports contourpy==1.3.3)
- Fixed transformers==4.55.2 + tokenizers==0.21.4 compatibility
- Regenerated requirements.lock.txt with compatible versions
- All tests pass locally